### PR TITLE
DEVADV-1159: Migrate all Gitpod envs to use Couchbase 7.0 GA

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,17 @@
-FROM deniswsrosa/couchbase7-5868-gitpod
+FROM couchbase:latest
 
-#Simple example on how to extend the image to install Java and maven
+RUN echo "* soft nproc 20000\n"\
+"* hard nproc 20000\n"\
+"* soft nofile 200000\n"\
+"* hard nofile 200000\n" >> /etc/security/limits.conf
+
 RUN apt-get -qq update && \
-     apt-get install -yq maven default-jdk
+     apt-get install -yq maven default-jdk sudo
+
+RUN addgroup --gid 33333 gitpod && \
+     useradd --no-log-init --create-home --home-dir /home/gitpod --shell /bin/bash --uid 33333 --gid 33333 gitpod && \
+     usermod -a -G gitpod,couchbase,sudo gitpod && \
+     echo 'gitpod ALL=(ALL) NOPASSWD:ALL'>> /etc/sudoers
+
+COPY startcb.sh /opt/couchbase/bin/startcb.sh
+USER gitpod

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,7 @@ image:
 
 tasks:
 - name: Start Couchbase
-  init:  cd /opt/couchbase/ && ./start-cb.sh
+  init: ./startcb.sh
 - name: Log use
   init: curl -s 'https://da-demo-images.s3.amazonaws.com/runItNow_outline.png?couchbase-example=java-transactions-quickstart-repo&source=gitpod' > /dev/null
 - name: Start app

--- a/startcb.sh
+++ b/startcb.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+OS_USER_GROUP="${OS_USER_GROUP:=gitpod:gitpod}"
+
+CB_USER="${CB_USER:-Administrator}"
+CB_PSWD="${CB_PSWD:-password}"
+CB_HOST="${CB_HOST:-127.0.0.1}"
+CB_PORT="${CB_PORT:-8091}"
+CB_NAME="${CB_NAME:-cbgitpod}"
+
+CB_SERVICES="${CB_SERVICES:-data,query,index,fts,eventing,analytics}"
+
+CB_KV_RAMSIZE="${CB_KV_RAMSIZE:-256}"
+CB_INDEX_RAMSIZE="${CB_INDEX_RAMSIZE:-256}"
+CB_FTS_RAMSIZE="${CB_FTS_RAMSIZE:-256}"
+CB_EVENTING_RAMSIZE="${CB_EVENTING_RAMSIZE:-512}"
+CB_ANALYTICS_RAMSIZE="${CB_ANALYTICS_RAMSIZE:-1024}"
+
+set -euo pipefail
+
+COUCHBASE_TOP=/opt/couchbase
+sudo chown -R ${OS_USER_GROUP} ${COUCHBASE_TOP}/var
+
+echo "Start couchbase..."
+couchbase-server --start
+
+echo "Waiting for couchbase-server..."
+until curl -s http://${CB_HOST}:${CB_PORT}/pools > /dev/null; do
+    sleep 5
+    echo "Waiting for couchbase-server..."
+done
+
+echo "Waiting for couchbase-server... ready"
+
+if ! couchbase-cli server-list -c ${CB_HOST}:${CB_PORT} -u ${CB_USER} -p ${CB_PSWD} > /dev/null; then
+  echo "couchbase cluster-init..."
+  couchbase-cli cluster-init \
+        --services ${CB_SERVICES} \
+        --cluster-name ${CB_NAME} \
+        --cluster-username ${CB_USER} \
+        --cluster-password ${CB_PSWD} \
+        --cluster-ramsize ${CB_KV_RAMSIZE} \
+        --cluster-index-ramsize ${CB_INDEX_RAMSIZE} \
+        --cluster-fts-ramsize ${CB_FTS_RAMSIZE} \
+        --cluster-eventing-ramsize ${CB_EVENTING_RAMSIZE} \
+        --cluster-analytics-ramsize ${CB_ANALYTICS_RAMSIZE}
+fi
+
+sleep 3


### PR DESCRIPTION
Changes with gitpod and couchbase:latest (7.0) official docker image seems ok. Executed a couple of credit transfers on the simple browser popup window and works fine.
See the screenshot.
<img width="1677" alt="Screen Shot 2021-08-17 at 11 41 09 AM" src="https://user-images.githubusercontent.com/51489795/129782762-32427947-56f5-473b-97d7-c9232f84c64e.png">


